### PR TITLE
Extended discarding functionality and a couple of minor changes

### DIFF
--- a/pyCardDeck/deck.py
+++ b/pyCardDeck/deck.py
@@ -239,7 +239,6 @@ class Deck:
         """
         self._cards = []
 
-
     def add_single(self, card: CardType, position: int = False) -> None:
         """
         Shuffles (or inserts) a single card into the active deck

--- a/pyCardDeck/deck.py
+++ b/pyCardDeck/deck.py
@@ -222,6 +222,13 @@ class Deck:
             raise NotACard('You tried to insert {} (rank({}) into a discard pile'
                            .format(card, type(card).__name__))
 
+    def clear(self) -> None:
+        """
+        Empties the deck, destroying contents
+        """
+        self._cards = []
+
+
     def add_single(self, card: CardType, position: int = False) -> None:
         """
         Shuffles (or inserts) a single card into the active deck

--- a/pyCardDeck/deck.py
+++ b/pyCardDeck/deck.py
@@ -27,9 +27,11 @@ class Deck:
     :type reshuffle:    bool
     :param name:        Name of the deck, used when converting the Deck instance into string
     :type name:         string
+    :param discard:     optional Deck object to use as discard pile
+    :type discard:      Union[Deck, None]
     """
 
-    def __init__(self, cards: object = None, reshuffle: object = True, name: object = None):
+    def __init__(self, cards: object = None, reshuffle: object = True, name: object = None, discard: Union['Deck', None] = None):
         """
         Create the deck
         """
@@ -38,7 +40,10 @@ class Deck:
         self._cards = cards
         if self._cards is None:
             self._cards = []
-        self._discard_pile = []
+        if discard is None:
+            self._discard_pile = []
+        else:
+            self._discard_pile = discard
         self._reshuffle = reshuffle
         self._save_location = None
 
@@ -198,7 +203,10 @@ class Deck:
         for card in self._discard_pile:
             self._cards.append(card)
         self.shuffle()
-        self._discard_pile = []
+        if isinstance(self._discard_pile, Deck):
+            self._discard_pile.clear()
+        else:
+            self._discard_pile = []
         log.debug('Cards have been shuffled back from the discard pile')
 
     def discard(self, card: CardType) -> None:
@@ -211,7 +219,10 @@ class Deck:
         """
         log.debug("Card being discarded: %s", card)
         if card or type(card) == int:
-            self._discard_pile.append(card)
+            if isinstance(self._discard_pile, Deck):
+                self._discard_pile.add_single(card, 0)
+            else:
+                self._discard_pile.append(card)
             log.debug('Card %s discarded', card)
         # This had a reason, I remember testing something and ending
         # up with False/None in discard_pile - if anyone knows what

--- a/pyCardDeck/deck.py
+++ b/pyCardDeck/deck.py
@@ -502,7 +502,7 @@ class Deck:
         """
         return len(self._cards)
 
-    def __getitem__(self, position):
+    def __getitem__(self, position: int) -> CardType:
         """
         For more pythonic usage
 
@@ -510,7 +510,7 @@ class Deck:
         """
         return self._cards[position]
 
-    def __setitem__(self, position, card):
+    def __setitem__(self, position: int, card: CardType) -> None:
         """
         For more pythonic usage
 

--- a/pyCardDeck/deck.py
+++ b/pyCardDeck/deck.py
@@ -7,7 +7,7 @@ import yaml
 import jsonpickle
 # noinspection PyCompatibility
 # because we are installing it through pip
-from typing import List
+from typing import List, Iterable, Union
 from random import shuffle, randint, randrange
 from .errors import OutOfCards, NotACard, NoCards, CardNotFound, UnknownFormat
 from .cards import CardType
@@ -499,6 +499,12 @@ class Deck:
         Allows for things like random.shuffle(Deck)
         """
         self._cards[position] = card
+
+    def __iter__(self) -> Iterable[CardType]:
+        """
+        For faster pythonic iteration protected against internal changes
+        """
+        return iter(self._cards)
 
 
 def _card_compare(card: CardType, second_card: CardType) -> bool:

--- a/tests/test_deck.py
+++ b/tests/test_deck.py
@@ -170,6 +170,23 @@ def test_discard():
     assert d.discarded == 3
 
 
+def test_deck_discard():
+    cardlist = [
+        Card('One'), Card('Two'), Card('Three'), Card('Four')
+    ]
+    discardpile = Deck(reshuffle=False)
+    d = Deck(cards=cardlist[:], reshuffle=False, discard=discardpile)
+    d.discard(d.draw())
+    d.discard(d.draw())
+    assert d.discarded == 2
+    assert len(discardpile) == 2
+    assert discardpile[1] == cardlist[0]
+    d.shuffle_back()
+    assert d.discarded == 0
+    assert len(d) == 4
+    assert len(discardpile) == 0
+
+
 def test_shuffle_back():
     d = Deck(cards=[
         Card('One'), Card('Two'), Card('Three'), Card('Four')


### PR DESCRIPTION
The primary change is adding the ability for a second `Deck` object to be registered as the discard pile.  This allows for inspection and manipulation of the discard pile using all the deck methods without having to access the internal `_discard_pile`.  Useful for games where the contents of discard piles are open knowledge or have ongoing game effects (mostly deck-builders).

Not much needed changing, just a slight update to the shuffle_back method to avoid overwriting the discard pile and an added `clear` method to drop all the contents of a deck without having to replace the whole thing or go through one by one.  Also added in a unit test to make sure this functionality was working correctly.

Additional minor changes:
- Added type hints to `__getitem__` and `__setitem__` (they were the only methods lacking them)
- Added `__iter__` method (speeds up iteration and decouples it from the specific structure of `_cards`)